### PR TITLE
Fix duplicate package entry

### DIFF
--- a/autonomous_car/setup.sh
+++ b/autonomous_car/setup.sh
@@ -41,7 +41,6 @@ install_package "pigpio"
 install_package "python3-pigpio"
 install_package "libopencv-dev"
 install_package "v4l-utils"
-install_package "libboost-all-dev"
 install_package "libkissfft-dev"
 install_package "libcodec2-dev"
 


### PR DESCRIPTION
## Summary
- remove second `libboost-all-dev` package installation to keep unique package list

## Testing
- `grep -n install_package autonomous_car/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685dd68af008832bbc5e27a1cfbb8e20