### PR TITLE
Add Vercel build skip script

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -47,3 +47,10 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Skipping Vercel Builds
+
+This repository includes a `vercel.json` file configured with an ignored build step. The
+`scripts/skip-frontend-build.sh` script stops the Vercel build when no files inside the
+`frontend` directory changed. This helps avoid unnecessary deployments when working on
+other parts of the project.

--- a/scripts/skip-frontend-build.sh
+++ b/scripts/skip-frontend-build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Skip Vercel build if no changes were made in the frontend directory
+# When there are no changes in "frontend", this script outputs text and Vercel will skip the build.
+
+# Only run diff if we have a previous SHA
+if [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then
+  CHANGED=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" "$VERCEL_GIT_COMMIT_SHA" -- frontend)
+else
+  CHANGED=$(git ls-tree --name-only "$VERCEL_GIT_COMMIT_SHA" frontend)
+fi
+
+if [ -z "$CHANGED" ]; then
+  echo "No changes in frontend, skipping build."
+fi

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "bash ./scripts/skip-frontend-build.sh"
+}


### PR DESCRIPTION
## Summary
- configure Vercel to skip builds when the `frontend` folder has no changes
- document the ignored build step in `frontend/README.md`

## Testing
- `bash -n scripts/skip-frontend-build.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ddb6a0bec832ba62a6a8f4e22d4c3