### PR TITLE
Improve start scripts with graceful shutdown

### DIFF
--- a/autonomous_car_v2/start.sh
+++ b/autonomous_car_v2/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 GREEN="\033[1;32m"; RED="\033[1;31m"; BLUE="\033[1;34m"; RESET="\033[0m"
 info(){ echo -e "${BLUE}ℹ️ $1${RESET}"; }
@@ -16,8 +17,25 @@ else
 fi
 
 if [ -f ./autonomous_car_v2 ]; then
-  ./autonomous_car_v2
-  ok "Programa encerrado."
+  ./autonomous_car_v2 &
+  PID=$!
+
+  cleanup(){
+    if kill -0 "$PID" 2>/dev/null; then
+      info "Encerrando programa..."
+      kill "$PID" 2>/dev/null
+      wait "$PID" 2>/dev/null || true
+    fi
+  }
+  trap cleanup SIGINT SIGTERM
+
+  wait "$PID"
+  STATUS=$?
+  if [ $STATUS -ne 0 ]; then
+    error "Programa finalizado com erro ($STATUS)."
+  else
+    ok "Programa encerrado."
+  fi
 else
   error "Executável não encontrado."
   exit 1


### PR DESCRIPTION
## Summary
- enhance `start.sh` scripts to handle Ctrl+C gracefully
- add signal traps that terminate the running executable on exit

## Testing
- `bash -n autonomous_car/start.sh`
- `bash -n autonomous_car_v2/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e27f17384832b8a507f5777a3a819