### PR TITLE
Enable GPIO control and camera 4

### DIFF
--- a/autonomous_car_v2/CMakeLists.txt
+++ b/autonomous_car_v2/CMakeLists.txt
@@ -18,15 +18,21 @@ add_executable(autonomous_car_v2
     src/main.cpp
     include/managers/WebSocketManager.cpp
     include/video/VideoStreamHandler.cpp
+    include/commands/CommandProcessor.cpp
+    include/commands/handlers/AccelerateCommandHandler.cpp
+    include/commands/handlers/AlertCommandHandler.cpp
+    include/commands/handlers/BrakeCommandHandler.cpp
+    include/commands/handlers/TurnCommandHandler.cpp
 )
 
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(Threads REQUIRED)
+find_library(PIGPIO_LIB pigpio REQUIRED)
 
 target_link_libraries(autonomous_car_v2
     PRIVATE
         ${Boost_LIBRARIES}
         Threads::Threads
         ${OpenCV_LIBS}
-        # ${PIGPIO_LIB}
+        ${PIGPIO_LIB}
 )

--- a/autonomous_car_v2/README.md
+++ b/autonomous_car_v2/README.md
@@ -1,6 +1,6 @@
 # Autonomous Car v2
 
-Esta pasta contém a segunda versão simplificada do projeto do carro autônomo. Além do servidor WebSocket, esta versão já possui captura de vídeo para transmissão aos clientes.
+Esta pasta contém a segunda versão simplificada do projeto do carro autônomo. Além do servidor WebSocket, esta versão já possui captura de vídeo para transmissão aos clientes e controle dos motores via GPIO.
 
 ## Como compilar
 
@@ -14,4 +14,18 @@ Esta pasta contém a segunda versão simplificada do projeto do carro autônomo.
 ./start.sh
 ```
 
-O servidor WebSocket será iniciado na porta **8080**.
+O servidor WebSocket será iniciado na porta **8080**. A captura de vídeo utiliza a câmera de índice **4**, correspondente ao módulo conectado no *HaspBarrier*.
+
+## Pinagem GPIO
+
+As portas abaixo são usadas pelo `pigpio` para controlar os motores e o servo de direção:
+
+| Pino GPIO | Função | Comando |
+|-----------|---------------------------------------|----------------|
+| `17`      | Motor A1 – avançar | `accelerate` (velocidade > 0) |
+| `27`      | Motor A2 – ré | `accelerate` (velocidade < 0) |
+| `23`      | Motor B1 – avançar | `accelerate` (velocidade > 0) |
+| `22`      | Motor B2 – ré | `accelerate` (velocidade < 0) |
+| `18`      | Servo de direção | `turn` |
+
+Esses valores correspondem ao código fonte em `include/commands/handlers`. Ajuste conforme a sua fiação.

--- a/autonomous_car_v2/include/commands/CommandProcessor.cpp
+++ b/autonomous_car_v2/include/commands/CommandProcessor.cpp
@@ -1,0 +1,89 @@
+#include "CommandProcessor.h"
+#include "handlers/AccelerateCommandHandler.h"
+#include "handlers/AlertCommandHandler.h"
+#include "handlers/BrakeCommandHandler.h"
+#include "handlers/TurnCommandHandler.h"
+#include <iostream>
+#include <rapidjson/document.h>
+
+CommandProcessor::CommandProcessor() {
+  commandHandlers["accelerate"] = std::make_shared<AccelerateCommandHandler>();
+  commandHandlers["brake"]      = std::make_shared<BrakeCommandHandler>();
+  commandHandlers["turn"]       = std::make_shared<TurnCommandHandler>();
+  commandHandlers["alert"]      = std::make_shared<AlertCommandHandler>();
+}
+
+void CommandProcessor::processCommand(const std::string &jsonCommand) {
+  auto document = parseJson(jsonCommand);
+  if (!document) {
+    std::cerr << "Erro ao processar JSON." << std::endl;
+    return;
+  }
+
+  if (!isCommandMessage(*document)) {
+    std::cerr << "Mensagem inválida ou tipo não suportado." << std::endl;
+    return;
+  }
+
+  processPayload(document->GetObject()["payload"]);
+}
+
+void CommandProcessor::processConfig(const rapidjson::Value &configPayload) {
+  if (!configPayload.IsObject()) {
+    std::cerr << "Configuração inválida recebida." << std::endl;
+    return;
+  }
+
+  double speedLimit          = configPayload["speedLimit"].GetDouble();
+  double steeringSensitivity = configPayload["steeringSensitivity"].GetDouble();
+
+  PidControl pid;
+  pid.p = configPayload["pidControl"]["p"].GetDouble();
+  pid.i = configPayload["pidControl"]["i"].GetDouble();
+  pid.d = configPayload["pidControl"]["d"].GetDouble();
+
+  // Atualiza a configuração global do veículo
+  VehicleConfig::getInstance().updateConfig(speedLimit, steeringSensitivity, pid);
+
+  std::cout << "Configuração atualizada: Velocidade " << speedLimit
+            << ", Sensibilidade " << steeringSensitivity
+            << ", PID(" << pid.p << ", " << pid.i << ", " << pid.d << ")" << std::endl;
+}
+
+std::optional<rapidjson::Document> CommandProcessor::parseJson(const std::string &jsonString) const {
+  rapidjson::Document doc;
+  if (doc.Parse(jsonString.c_str()).HasParseError()) {
+    return std::nullopt;
+  }
+  return doc;
+}
+
+bool CommandProcessor::isCommandMessage(const rapidjson::Document &doc) const {
+  return doc.HasMember("type") && doc["type"].IsString() && std::string(doc["type"].GetString()) == "commands";
+}
+
+void CommandProcessor::processPayload(const rapidjson::Value &payload) {
+  if (!payload.IsArray()) {
+    std::cerr << "Payload inválido." << std::endl;
+    return;
+  }
+
+  for (const auto &cmd : payload.GetArray()) {
+    processSingleCommand(cmd);
+  }
+}
+
+void CommandProcessor::processSingleCommand(const rapidjson::Value &cmd) {
+  if (!cmd.HasMember("action") || !cmd["action"].IsString()) {
+    std::cerr << "Comando sem 'action' válida." << std::endl;
+    return;
+  }
+
+  std::string action = cmd["action"].GetString();
+  auto        it     = commandHandlers.find(action);
+  if (it != commandHandlers.end()) {
+    it->second->handle(cmd);
+  } else {
+    std::cerr << "Comando desconhecido: " << action << std::endl;
+  }
+}

--- a/autonomous_car_v2/include/commands/CommandProcessor.h
+++ b/autonomous_car_v2/include/commands/CommandProcessor.h
@@ -1,0 +1,36 @@
+#ifndef COMMAND_PROCESSOR_H
+#define COMMAND_PROCESSOR_H
+
+#include "../config/VehicleConfig.h"
+#include <functional>
+#include <memory>
+#include <optional>
+#include <rapidjson/document.h>
+#include <string>
+#include <unordered_map>
+
+// Interface para Handlers
+class CommandHandler {
+public:
+  virtual ~CommandHandler()                              = default;
+  virtual void handle(const rapidjson::Value &cmd) const = 0;
+};
+
+// Processador de Comandos
+class CommandProcessor {
+public:
+  CommandProcessor();
+  void processCommand(const std::string &command);
+
+private:
+  std::unordered_map<std::string, std::shared_ptr<CommandHandler>> commandHandlers;
+
+  // Funções auxiliares
+  std::optional<rapidjson::Document> parseJson(const std::string &jsonString) const;
+  bool                               isCommandMessage(const rapidjson::Document &doc) const;
+  void                               processPayload(const rapidjson::Value &payload);
+  void                               processSingleCommand(const rapidjson::Value &cmd);
+  void                               processConfig(const rapidjson::Value &configPayload);
+};
+
+#endif // COMMAND_PROCESSOR_H

--- a/autonomous_car_v2/include/commands/handlers/AccelerateCommandHandler.cpp
+++ b/autonomous_car_v2/include/commands/handlers/AccelerateCommandHandler.cpp
@@ -1,0 +1,65 @@
+#include "AccelerateCommandHandler.h"
+#include <iostream>
+#include <pigpio.h>
+
+// Definições dos pinos GPIO
+constexpr int PIN_FORWARD_A1  = 17; // GPIO para direção Forward
+constexpr int PIN_FORWARD_A2  = 27; // GPIO para direção Forward
+constexpr int PIN_BACKWARD_B1 = 23; // GPIO para direção Backward
+constexpr int PIN_BACKWARD_B2 = 22; // GPIO para direção Backward
+
+void AccelerateCommandHandler::handle(const rapidjson::Value &cmd) const {
+  setupGPIO();
+
+  if (cmd.HasMember("speed") && cmd["speed"].IsInt()) {
+    int speed = cmd["speed"].GetInt();
+    std::cout << "Comando recebido: Acelerar para " << speed << " km/h" << std::endl;
+
+    setMotorDirection(speed);
+    
+  } else {
+    std::cerr << "Comando 'accelerate' inválido: falta 'speed'." << std::endl;
+  }
+}
+
+void AccelerateCommandHandler::setupGPIO() const {
+  static bool isSetup = false;
+  if (!isSetup) {
+    if (gpioInitialise() < 0) {
+      std::cerr << "Falha ao inicializar pigpio." << std::endl;
+      exit(1);
+    }
+    gpioSetMode(PIN_FORWARD_A1, PI_OUTPUT);  // Configura pino Forward como saída
+    gpioSetMode(PIN_FORWARD_A2, PI_OUTPUT); // Configura pino Backward como saída
+    gpioSetMode(PIN_BACKWARD_B1, PI_OUTPUT);  // Configura pino Forward como saída
+    gpioSetMode(PIN_BACKWARD_B2, PI_OUTPUT); // Configura pino Backward como saída
+    isSetup = true;
+  }
+}
+
+void AccelerateCommandHandler::setMotorDirection(int speed) const {
+  if (speed > 0) {
+      std::cerr << "FRENTE." << std::endl;
+
+    gpioWrite(PIN_FORWARD_A1, PI_HIGH); // Ativa direção Forward
+    gpioWrite(PIN_BACKWARD_B1, PI_HIGH); // Desativa direção Backward
+    gpioWrite(PIN_FORWARD_A2, PI_LOW); // Ativa direção Forward
+    gpioWrite(PIN_BACKWARD_B2, PI_LOW); // Ativa direção Forward
+  } else if (speed < 0) {
+      std::cerr << "DANDO RE." << std::endl;
+
+    gpioWrite(PIN_FORWARD_A1, PI_LOW); // Ativa direção Forward
+    gpioWrite(PIN_BACKWARD_B1, PI_LOW); // Desativa direção Backward
+    gpioWrite(PIN_FORWARD_A2, PI_HIGH); // Ativa direção Forward
+    gpioWrite(PIN_BACKWARD_B2, PI_HIGH); // Ativa direção Forward
+    
+  } else {
+      std::cerr << "PARADO." << std::endl;
+
+    gpioWrite(PIN_FORWARD_A1, PI_LOW); // Ativa direção Forward
+    gpioWrite(PIN_BACKWARD_B1, PI_LOW); // Desativa direção Backward
+    gpioWrite(PIN_FORWARD_A2, PI_LOW); // Ativa direção Forward
+    gpioWrite(PIN_BACKWARD_B2, PI_LOW); // Ativa direção Forward
+  }
+}
+

--- a/autonomous_car_v2/include/commands/handlers/AccelerateCommandHandler.h
+++ b/autonomous_car_v2/include/commands/handlers/AccelerateCommandHandler.h
@@ -1,0 +1,15 @@
+#ifndef ACCELERATE_COMMAND_HANDLER_H
+#define ACCELERATE_COMMAND_HANDLER_H
+
+#include "../CommandProcessor.h"
+
+class AccelerateCommandHandler : public CommandHandler {
+public:
+  void handle(const rapidjson::Value &cmd) const override;
+
+private:
+  void setupGPIO() const;
+  void setMotorDirection(int speed) const;
+};
+
+#endif // ACCELERATE_COMMAND_HANDLER_H

--- a/autonomous_car_v2/include/commands/handlers/AlertCommandHandler.cpp
+++ b/autonomous_car_v2/include/commands/handlers/AlertCommandHandler.cpp
@@ -1,0 +1,6 @@
+#include "AlertCommandHandler.h"
+#include <iostream>
+
+void AlertCommandHandler::handle(const rapidjson::Value &) const {
+  std::cout << "Comando recebido: Ligar alerta" << std::endl;
+}

--- a/autonomous_car_v2/include/commands/handlers/AlertCommandHandler.h
+++ b/autonomous_car_v2/include/commands/handlers/AlertCommandHandler.h
@@ -1,0 +1,11 @@
+#ifndef ALERT_COMMAND_HANDLER_H
+#define ALERT_COMMAND_HANDLER_H
+
+#include "../CommandProcessor.h"
+
+class AlertCommandHandler : public CommandHandler {
+public:
+  void handle(const rapidjson::Value &cmd) const override;
+};
+
+#endif // ALERT_COMMAND_HANDLER_H

--- a/autonomous_car_v2/include/commands/handlers/BrakeCommandHandler.cpp
+++ b/autonomous_car_v2/include/commands/handlers/BrakeCommandHandler.cpp
@@ -1,0 +1,6 @@
+#include "BrakeCommandHandler.h"
+#include <iostream>
+
+void BrakeCommandHandler::handle(const rapidjson::Value &) const {
+  std::cout << "Comando recebido: Frear" << std::endl;
+}

--- a/autonomous_car_v2/include/commands/handlers/BrakeCommandHandler.h
+++ b/autonomous_car_v2/include/commands/handlers/BrakeCommandHandler.h
@@ -1,0 +1,11 @@
+#ifndef BRAKE_COMMAND_HANDLER_H
+#define BRAKE_COMMAND_HANDLER_H
+
+#include "../CommandProcessor.h"
+
+class BrakeCommandHandler : public CommandHandler {
+public:
+  void handle(const rapidjson::Value &cmd) const override;
+};
+
+#endif // BRAKE_COMMAND_HANDLER_H

--- a/autonomous_car_v2/include/commands/handlers/TurnCommandHandler.cpp
+++ b/autonomous_car_v2/include/commands/handlers/TurnCommandHandler.cpp
@@ -1,0 +1,51 @@
+#include "TurnCommandHandler.h"
+#include <algorithm> // para std::clamp
+#include <cstdlib>
+#include <iostream>
+#include <pigpio.h>
+
+#define SERVO_PIN 18 // Pino GPIO usado pelo servo
+#define MIN_PULSE 1100
+#define MAX_PULSE 1750
+
+TurnCommandHandler::TurnCommandHandler()
+    : currentPulse(config.initialPulse) { // Inicializa o pulso com o valor inicial
+  setupGPIO();
+  setServoPulse(currentPulse); // Define o pulso inicial
+}
+
+void TurnCommandHandler::handle(const rapidjson::Value &cmd) const {
+  if (cmd.HasMember("direction") && cmd["direction"].IsString()) {
+    std::string direction   = cmd["direction"].GetString();
+    double      sensitivity = VehicleConfig::getInstance().steeringSensitivity; // Obtém a sensibilidade
+
+    int increment = static_cast<int>(config.increment * sensitivity); // Ajusta conforme sensibilidade
+
+    if (direction == "left") {
+      currentPulse = std::max(config.minPulse, currentPulse - increment);
+    } else if (direction == "right") {
+      currentPulse = std::min(config.maxPulse, currentPulse + increment);
+    }
+
+    setServoPulse(currentPulse);
+  }
+}
+
+void TurnCommandHandler::setupGPIO() const {
+  static bool isSetup = false;
+  if (!isSetup) {
+    if (gpioInitialise() < 0) {
+      std::cerr << "Falha ao inicializar pigpio." << std::endl;
+      exit(1);
+    }
+
+    std::cout << "Pino GPIO " << SERVO_PIN << " configurado como saída para o servo." << std::endl;
+    isSetup = true;
+  }
+}
+
+void TurnCommandHandler::setServoPulse(int pulseWidth) const {
+  // clamp no intervalo válido antes de chamar o driver
+  pulseWidth = std::clamp(pulseWidth, MIN_PULSE, MAX_PULSE);
+  gpioServo(SERVO_PIN, pulseWidth);
+}

--- a/autonomous_car_v2/include/commands/handlers/TurnCommandHandler.cpp
+++ b/autonomous_car_v2/include/commands/handlers/TurnCommandHandler.cpp
@@ -22,8 +22,10 @@ void TurnCommandHandler::handle(const rapidjson::Value &cmd) const {
     int increment = static_cast<int>(config.increment * sensitivity); // Ajusta conforme sensibilidade
 
     if (direction == "left") {
+      std::cout << "Comando recebido: Virar à esquerda" << std::endl;
       currentPulse = std::max(config.minPulse, currentPulse - increment);
     } else if (direction == "right") {
+      std::cout << "Comando recebido: Virar à direita" << std::endl;
       currentPulse = std::min(config.maxPulse, currentPulse + increment);
     }
 

--- a/autonomous_car_v2/include/commands/handlers/TurnCommandHandler.h
+++ b/autonomous_car_v2/include/commands/handlers/TurnCommandHandler.h
@@ -1,0 +1,27 @@
+#ifndef TURN_COMMAND_HANDLER_H
+#define TURN_COMMAND_HANDLER_H
+
+#include "../CommandProcessor.h"
+
+class ServoConfig {
+public:
+  int initialPulse = 1500; // Pulso inicial (neutro)
+  int minPulse     = 1100; // Pulso mínimo para a esquerda
+  int maxPulse     = 1850; // Pulso máximo para a direita
+  int increment    = 100;   // Sensibilidade (incremento/decremento)
+};
+
+class TurnCommandHandler : public CommandHandler {
+public:
+  TurnCommandHandler();
+  void handle(const rapidjson::Value &cmd) const override;
+
+private:
+  void setupGPIO() const;
+  void setServoPulse(int pulseWidth) const;
+
+  mutable int currentPulse; // Armazena o pulso atual
+  ServoConfig config;       // Configurações do servo
+};
+
+#endif // TURN_COMMAND_HANDLER_H


### PR DESCRIPTION
## Summary
- port command handlers from v1
- link pigpio and compile command sources
- change camera index to 4 and init pigpio
- document GPIO support and camera index
- document GPIO pin assignments

## Testing
- `bash autonomous_car_v2/build.sh` *(fails: could not find OpenCV)*

------
https://chatgpt.com/codex/tasks/task_e_685e36517d54832bba7c2a8b2b0cdc5a